### PR TITLE
Add Next.js application deployment and service

### DIFF
--- a/09-deploymentAndService-frontend.yaml
+++ b/09-deploymentAndService-frontend.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: main-project
+  name: frontend-deployment
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nextjs
+  template:
+    metadata:
+      labels:
+        app: nextjs
+    spec:
+      containers:
+        - name: nextjs
+          image: jfer11/thesis-frontend:v1-release
+          ports:
+            - containerPort: 3000
+          # imagePullPolicy: Always
+          command: ["npm","run","start"]
+          # envFrom:
+          #   - configMapRef:
+          #       name: frontend-secret
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: main-project
+  name: frontend-service
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 3001
+      targetPort: 3000
+      nodePort: 30002
+  selector:
+    app: nextjs

--- a/apply.sh
+++ b/apply.sh
@@ -11,6 +11,7 @@ yaml_files=(
     06-service-postgres.yaml
     07-configMap-backend.yaml
     08-deploymentAndService-backend.yaml
+    09-deploymentAndService-frontend.yaml
 )
 
 for file in "${yaml_files[@]}"

--- a/delete.sh
+++ b/delete.sh
@@ -3,6 +3,7 @@
 set -e
 
 yaml_files=(
+    09-deploymentAndService-frontend.yaml
     08-deploymentAndService-backend.yaml
     07-configMap-backend.yaml
     06-service-postgres.yaml


### PR DESCRIPTION
### Description

This PR introduces a Kubernetes Deployment and Service YAML file for the main-project namespace. The Deployment sets up a replica set of 3 pods running a Next.js application using the image `jfer11/thesis-frontend:v1-release`. The Service exposes the application via a LoadBalancer on port `3001`, which forwards traffic to the pods on port `3000`. This will allow the application to be accessible to external users in a development environment.