### PR TITLE
Update Ingress Config and EKS Node Group Size

### DIFF
--- a/k8s-resources/aws-eks-production-cluster/09-ingress.yaml
+++ b/k8s-resources/aws-eks-production-cluster/09-ingress.yaml
@@ -6,16 +6,22 @@ metadata:
   annotations:
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
+    # by default, it will create a listener rule on port 80
+    # you can specify both ports as well like this: '[{"HTTP": 80}, {"HTTPS": 443}]'
+    # alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}, {"HTTP":80}]'  # Or just '[{"HTTPS": 443}]', creo que es mejor poner solo este.
+    # alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-1:411686525067:certificate/8adf7812-a1af-4eae-af1b-ea425a238a67
+    # # alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-1-2017-01 #Optional (Picks default if not used)    
 spec:
   ingressClassName: alb
   rules:
+    # - host: ssldemo.kubeoncloud.com    # SSL Setting (Optional only if we are not using certificate-arn annotation)
     - http:
         paths:
           - path: /
             pathType: Prefix
             backend:
               service:
-                name: backend-service
+                name: frontend-service
                 port:
-                  number: 5001
+                  number: 3001
 #   - host: TOBECHANGED  # Cambiar esto por lo que devuelva: kubectl get ingress

--- a/terraform/2-eks.tf
+++ b/terraform/2-eks.tf
@@ -19,8 +19,8 @@ module "eks" {
 
   eks_managed_node_groups = {
     general = {
-      desired_size = 1
-      min_size     = 1
+      desired_size = 2
+      min_size     = 2
       max_size     = 10
 
       labels = {


### PR DESCRIPTION
This pull request includes two main updates:

1. Ingress Configuration: Added important comments to the ingress configuration in the Kubernetes YAML file. These comments provide additional context and guidance for the ALB ingress controller annotations, such as the target type, listener ports, and certificate ARN.
 
2. EKS Managed Node Group: Updated the desired_size and min_size of the EKS managed node group in the `eks.tf` Terraform file. Both values have been changed from 1 to 2, which will help ensure that there are at least two worker nodes running at all times in the general node group.